### PR TITLE
Change mixin priority to enable compatibility with C2ME

### DIFF
--- a/src/main/java/io/github/maloryware/magmaphile/mixin/LavaWorldGenHeight.java
+++ b/src/main/java/io/github/maloryware/magmaphile/mixin/LavaWorldGenHeight.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Debug(export = true)
-@Mixin(NoiseChunkGenerator.class)
+@Mixin(NoiseChunkGenerator.class, priority = 1200) //fire mixin after C2ME (let's see if it still explodes, works, or explodes but to the left)
 public class LavaWorldGenHeight {
 
 

--- a/src/main/java/io/github/maloryware/magmaphile/mixin/LavaWorldGenHeight.java
+++ b/src/main/java/io/github/maloryware/magmaphile/mixin/LavaWorldGenHeight.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Debug(export = true)
-@Mixin(value = NoiseChunkGenerator.class, priority = 1200) //fire mixin after C2ME (let's see if it still explodes, works, or explodes but to the left)
+@Mixin(value = NoiseChunkGenerator.class, priority = 1200) //fire mixin after C2ME
 public class LavaWorldGenHeight {
 
 

--- a/src/main/java/io/github/maloryware/magmaphile/mixin/LavaWorldGenHeight.java
+++ b/src/main/java/io/github/maloryware/magmaphile/mixin/LavaWorldGenHeight.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
 @Debug(export = true)
-@Mixin(NoiseChunkGenerator.class, priority = 1200) //fire mixin after C2ME (let's see if it still explodes, works, or explodes but to the left)
+@Mixin(value = NoiseChunkGenerator.class, priority = 1200) //fire mixin after C2ME (let's see if it still explodes, works, or explodes but to the left)
 public class LavaWorldGenHeight {
 
 


### PR DESCRIPTION
changed mixin priority to 1200 (from default 1000) so that it fires after C2ME's everything, allowing both to be used
It seems to work fine, at least with a quick test using the datapack you yourself mentioned
(idk why like 53 do that)